### PR TITLE
Add a roundtrip fuzz target using miniz_oxide

### DIFF
--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -11,7 +11,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 flate2 = { version = "1.0", features = [] }
-miniz_oxide = { version = "0.7.1", features = ["std"] }
+miniz_oxide = { version = "0.7.1", features = ["std", "simd"] }
 
 [dependencies.fdeflate]
 path = ".."
@@ -35,5 +35,11 @@ doc = false
 [[bin]]
 name = "inflate"
 path = "fuzz_targets/inflate.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "inflate_miniz"
+path = "fuzz_targets/inflate_miniz.rs"
 test = false
 doc = false

--- a/fuzz/fuzz_targets/inflate_miniz.rs
+++ b/fuzz/fuzz_targets/inflate_miniz.rs
@@ -1,0 +1,11 @@
+#![no_main]
+#[macro_use] extern crate libfuzzer_sys;
+extern crate miniz_oxide;
+
+fuzz_target!(|input: (u8, Vec<u8>)| {
+    let compression_level = input.0;
+    let data = input.1;
+    let compressed = miniz_oxide::deflate::compress_to_vec_zlib(&data, compression_level);
+    let decompressed = fdeflate::decompress_to_vec(&compressed).expect("Decompression failed!");
+    assert_eq!(data, decompressed);
+});


### PR DESCRIPTION
Verifies that `fdeflate` can correctly decode whatever `miniz_oxide` encodes.

`miniz_oxide` itself is verified in the same fashion in https://github.com/Frommi/miniz_oxide/pull/138