### PR TITLE
Release 0.3.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,12 @@
 # Changelog
 
+## 0.3.3
+
+- Add `decompress_to_vec_bounded` method.
+
 ## 0.3.2
 
 - Allow decoding into buffers without extra space.
-- Add `decompress_to_vec_bounded` method.
 
 ## 0.3.1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdeflate"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`
@@ -9,6 +9,7 @@ rust-version = "1.57.0"
 license = "MIT OR Apache-2.0"
 description = "Fast specialized deflate implementation"
 authors = ["The image-rs Developers"]
+include = ["/src", "README.md", "LICENSE-APACHE", "LICENSE-MIT"]
 
 # crates.io metadata
 documentation = "https://docs.rs/fdeflate"

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1015,14 +1015,19 @@ pub fn decompress_to_vec(input: &[u8]) -> Result<Vec<u8>, DecompressionError> {
     }
 }
 
-// An error encountered while decompressing a deflate stream given a bounded
-// maximum output.
+/// An error encountered while decompressing a deflate stream given a bounded maximum output.
 pub enum BoundedDecompressionError {
     /// The input is not a valid deflate stream.
-    DecompressionError { inner: DecompressionError },
+    DecompressionError {
+        /// The underlying error.
+        inner: DecompressionError,
+    },
 
     /// The output is too large.
-    OutputTooLarge { partial_output: Vec<u8> },
+    OutputTooLarge {
+        /// The output decoded so far.
+        partial_output: Vec<u8>,
+    },
 }
 impl From<DecompressionError> for BoundedDecompressionError {
     fn from(inner: DecompressionError) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,10 @@ mod decompress;
 mod tables;
 
 pub use compress::{compress_to_vec, Compressor, StoredOnlyCompressor};
-pub use decompress::{decompress_to_vec, DecompressionError, Decompressor};
+pub use decompress::{
+    decompress_to_vec, decompress_to_vec_bounded, BoundedDecompressionError, DecompressionError,
+    Decompressor,
+};
 
 /// Build a length limited huffman tree.
 ///


### PR DESCRIPTION
The `decompress_to_vec_bounded` method was meant to be included in the prior release, but accidentally wasn't exported publicly.