### PR TITLE
Correct check from when we required an extra byte in output buffer

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -990,7 +990,7 @@ impl Decompressor {
             self.checksum.write(&output[output_position..output_index]);
         }
 
-        if self.state == State::Done || !end_of_input || output_index >= output.len() - 1 {
+        if self.state == State::Done || !end_of_input || output_index == output.len() {
             let input_left = remaining_input.len();
             Ok((input.len() - input_left, output_index - output_position))
         } else {


### PR DESCRIPTION
This could cause the decoder to erroneously report success for truncated deflate streams when `end_of_input` was passed.