### PR TITLE
Prevent spurious InvalidDistanceCode errors

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -743,7 +743,7 @@ impl Decompressor {
                     (dist_entry >> 8) as u8,
                     dist_entry as u8,
                 )
-            } else {
+            } else if self.nbits > litlen_code_bits + length_extra_bits + 9 {
                 let mut dist_extra_bits = 0;
                 let mut dist_base = 0;
                 let mut dist_advance_bits = 0;
@@ -761,6 +761,8 @@ impl Decompressor {
                     return Err(DecompressionError::InvalidDistanceCode);
                 }
                 (dist_base, dist_extra_bits, dist_advance_bits)
+            } else {
+                break;
             };
             bits >>= dist_code_bits;
 


### PR DESCRIPTION
Normally in a deflate bitstream all distance codes are valid. However, there are two cases where distance codes can be invalid: 

1. If there is only one distance with non-zero code length, it is assigned code `0` and code `1` is invalid.
2. If all distance code lengths are zero, then back references cannot appear in the bitstream and all distance codes are invalid. Notably, however, it is permissible for length codes to be defined in the block header as long as they never appear in the bitstream itself.

Case (2) turns out to be a problem if we don't specifically account for it...

This is because fdeflate uses the bits it has read so far concatenated with padding bits when decoding the next symbol. This way it doesn't need a full 8-bytes of input data if the next symbol is only a couple bits (and so it can handle the final symbols in a bitstream). After a symbol is read, we check whether that symbol used any of padding bits and bail if so. If padding bits were used then the resulting symbol won't necessarily match what is actually present in the bitstream, but  because huffman codes are prefix codes, whatever symbol comes next _must_ require more bits than we have so far.

Normally we try to read a full length-distance pair of symbols before checking whether enough bits are available. But unfortunately, the check for valid distance symbols came before the check for there being enough bits, leading to the spurious error.

This PR moves the check earlier, and also adds a small optimization: The distance code slowpath is only used for distance codes that are 10+ bits, so before taking the slowpath for decoding a distance symbol we first check whether we have at least 10 bits beyond the number required for the length symbol