### PR TITLE
Proof of concept: Higher compression mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ homepage = "https://github.com/image-rs/fdeflate"
 categories = ["compression"]
 
 [dependencies]
+innumerable = "0.1.0"
 simd-adler32 = "0.3.4"
 
 [dev-dependencies]

--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -293,6 +293,7 @@ impl Decompressor {
                 self.fill_buffer(remaining_input);
             }
         }
+
         let code_length_codes: [u16; 19] = crate::compute_codes(&code_length_lengths)
             .ok_or(DecompressionError::BadCodeLengthHuffmanTree)?;
 
@@ -1251,6 +1252,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn zero_length() {
         let mut compressed = crate::compress_to_vec(b"").to_vec();
 


### PR DESCRIPTION
This is a proof of concept that replaces the existing encoder with a slower but higher-compression one (an actual implementation would likely expose both as separate modes). On some PNG data I experimented on, its was as fast as miniz_oxide's level=2 but got a compression ratio better than miniz_oxide's level=9.

The key insight is that PNG data has a very skewed distribution of symbols which often makes short back-references worse than simply encoding the same data with literals. This decoder doesn't even attempt to find 3-byte back-references and 4-7 byte back-references are only used if they are likely to require fewer bits than the equivalent sequence of literals. The encoder uses a hash-table of 8 byte sequences and a separate one for 4 byte sequences. This means that with only two hash look-ups per-byte the encoder has a good chance of finding matches for most look-ups (due to the 4-byte sequence table) but doesn't risk missing 8+ byte sequences that give the biggest compression wins.

To estimate the frequency of symbols (which determines whether literals or back-references are better), the first 128 KB of the data assumes the hard-coded symbol frequencies used for the existing ultra-fast mode. Then each subsequent block of 128 KB uses the frequencies from the previous block.

Results on raw PNG IDAT data produced by re-encoding the [QOI benchmark suite images](https://qoiformat.org/benchmark/)...
```
Encoder[level]     Speed          Ratio
--------------     -----------    ------
fdeflate:          0.128 GiB/s    24.14%

miniz_oxide[0]:    0.123 GiB/s    100.02%
miniz_oxide[1]:    0.285 GiB/s    28.17%
miniz_oxide[2]:    0.128 GiB/s    26.12%
miniz_oxide[3]:    0.081 GiB/s    25.36%
miniz_oxide[4]:    0.069 GiB/s    25.24%
miniz_oxide[5]:    0.054 GiB/s    24.97%
miniz_oxide[6]:    0.028 GiB/s    24.55%
miniz_oxide[7]:    0.020 GiB/s    24.41%
miniz_oxide[8]:    0.015 GiB/s    24.34%
miniz_oxide[9]:    0.012 GiB/s    24.30%

zlib-rs[0]:        5.492 GiB/s    100.02%
zlib-rs[1]:        0.305 GiB/s    36.79%
zlib-rs[2]:        0.165 GiB/s    25.78%
zlib-rs[3]:        0.140 GiB/s    25.15%
zlib-rs[4]:        0.115 GiB/s    24.77%
zlib-rs[5]:        0.103 GiB/s    24.58%
zlib-rs[6]:        0.074 GiB/s    24.35%
zlib-rs[7]:        0.046 GiB/s    24.05%
zlib-rs[8]:        0.024 GiB/s    23.92%
zlib-rs[9]:        0.015 GiB/s    24.12%
```

<details>
  <summary>zlib and zlib-ng</summary>
  
  ```
zlib[0]:           2.359 GiB/s    100.02%
zlib[1]:           0.167 GiB/s    26.99%
zlib[2]:           0.150 GiB/s    26.55%
zlib[3]:           0.098 GiB/s    25.97%
zlib[4]:           0.094 GiB/s    25.45%
zlib[5]:           0.060 GiB/s    24.97%
zlib[6]:           0.033 GiB/s    24.54%
zlib[7]:           0.024 GiB/s    24.41%
zlib[8]:           0.012 GiB/s    24.23%
zlib[9]:           0.007 GiB/s    24.16%

zlib-ng[0]:        6.785 GiB/s    100.02%
zlib-ng[1]:        0.416 GiB/s    36.79%
zlib-ng[2]:        0.217 GiB/s    25.78%
zlib-ng[3]:        0.188 GiB/s    25.15%
zlib-ng[4]:        0.146 GiB/s    24.77%
zlib-ng[5]:        0.129 GiB/s    24.58%
zlib-ng[6]:        0.087 GiB/s    24.35%
zlib-ng[7]:        0.050 GiB/s    24.05%
zlib-ng[8]:        0.026 GiB/s    23.92%
zlib-ng[9]:        0.016 GiB/s    24.12%
  ```
</details>