### PR TITLE
Release 0.3.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.3.5
+
+- Fix handling of invalid inputs, so that errors are consistently detected
+  regardless of how the input is "chunked" when feeding it into the
+  decompressor.
+- Add more fuzz testing.
+
 ## 0.3.4
 
 - Fix bug where `Decompressor::read` might fail to return an error for a

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdeflate"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`


### PR DESCRIPTION
PTAL?

I wonder if it would be possible to release a minor version update of `fdeflate`.  I don't really understand what exactly is involved in the release process, but I hope that this commit helps (?).  Please let me know if this is not helpful or if some other actions may help.  (IIUC creating a git tag in _my_ fork/repo wouldn't help.)

Motivation: I've been running `fdeflate` (`inflate_bytewise3`) and `png` (`buf_independent`) fuzzers locally and they didn't find any new issues in the last day or so (this covers/includes the original and minimized testcases from https://oss-fuzz.com/crash-stats?project=image-png).  So, I hope that 1) the newly released version will be automatically picked up by OSS Fuzz, and 2) this will address all the `buf_independent` reports at https://oss-fuzz.com/crash-stats?project=image-png.