### PR TITLE
Release v0.3.6

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.3.6
+
+This release improves end-to-end decoding peformance for PNG images by 10% on average,
+with select images benefitting by as much as 50%.
+These improvements were inspired by the algorithms in `zune-inflate`.
+
+- Optimized building the Huffman table, which helps the performance of small images ([#31])
+- Dropped the specialized fast path for a hardcoded Huffman table, which is no longer necessary ([#32])
+- Add a fast path to the DEFLATE decoding loop that processes more bytes at a time, benefitting performance on large images ([#34])
+- Re-add test files into the crates.io tarball since they are so small. They may be removed in the future if they grow in size ([#35])
+
+[#31]: https://github.com/image-rs/fdeflate/pull/31
+[#32]: https://github.com/image-rs/fdeflate/pull/32
+[#34]: https://github.com/image-rs/fdeflate/pull/34
+[#35]: https://github.com/image-rs/fdeflate/pull/35
+
+
 ## 0.3.5
 
 - Fix handling of invalid inputs, so that errors are consistently detected

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fdeflate"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`

--- a/README.md
+++ b/README.md
@@ -4,19 +4,19 @@
 [![Documentation](https://docs.rs/fdeflate/badge.svg)](https://docs.rs/fdeflate)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/image-rs/fdeflate/rust.yml?label=Rust%20CI)](https://github.com/image-rs/fdeflate/actions)
 
-A fast deflate implementation.
+A fast and safe deflate implementation for PNG.
 
-This crate contains an optimized implementation of the deflate algorithm tuned to compress PNG
-images. It is compatible with standard zlib, but make a bunch of simplifying assumptions that
-drastically improve encoding performance:
+This crate contains an optimized implementation of the [deflate algorithm](https://en.wikipedia.org/wiki/Deflate) tuned for PNG images.
+
+At least on PNG data, our decoder rivals the performance of `zlib-ng` and `zlib-rs` without using any `unsafe` code.
+
+When compressing it makes a bunch of simplifying assumptions that
+drastically improve encoding speed while still being compatible with zlib:
 
 - Exactly one block per deflate stream.
 - No distance codes except for run length encoding of zeros.
 - A single fixed huffman tree trained on a large corpus of PNG images.
 - All huffman codes are <= 12 bits.
-
-It also contains a fast decompressor that supports arbitrary zlib streams but does especially
-well on streams that meet the above assumptions.
 
 ### Inspiration
 


### PR DESCRIPTION
Also updates README.md now that the specialized fast-path for images created with our encoder is gone