### PR TITLE
Different formulation of bit reader hot loop with a more concise assembly

### DIFF
--- a/src/decompress.rs
+++ b/src/decompress.rs
@@ -1036,9 +1036,11 @@ impl BitBuffer {
 
     fn fill_buffer(&mut self, input: &mut &[u8]) {
         if input.len() >= 8 {
-            self.buffer |= u64::from_le_bytes(input[..8].try_into().unwrap()) << self.nbits;
-            *input = &input[(63 - self.nbits as usize) / 8..];
-            self.nbits |= 56;
+            let mut bits = self.nbits & 63; // limits `bits` to 63 or less, elides bounds checks
+            self.buffer |= u64::from_le_bytes(input[..8].try_into().unwrap()) << bits;
+            *input = &input[(63 - bits as usize) / 8..];
+            bits |= 56;
+            self.nbits = bits;
         } else {
             let nbytes = input.len().min((63 - self.nbits as usize) / 8);
             let mut input_data = [0; 8];


### PR DESCRIPTION
Assembly before: https://godbolt.org/z/o9KsYfoaE
Assembly after: https://godbolt.org/z/szbfavKKh

I haven't measured if this actually noticeable in practice, my machine is just too noisy.