### PR TITLE
Try fixed Huffman codes and uncompressed blocks 

### DIFF
--- a/src/compress/bitstream.rs
+++ b/src/compress/bitstream.rs
@@ -116,6 +116,52 @@ pub(crate) fn write_block<W: Write>(
         7,
     );
 
+    // If the input is small, then check whether and uncompressed block would be
+    // cheaper.
+    if data.len() < 1024 {
+        let mut cost = 14 + 19 * 3;
+        for &length in lengths[..num_litlen_codes]
+            .iter()
+            .chain(&dist_lengths[..num_dist_codes])
+        {
+            cost += code_length_lengths[length as usize] as u32;
+        }
+
+        for symbol in symbols {
+            match symbol {
+                Symbol::LiteralRun { start, end } => {
+                    for &lit in &data[(*start - base_index) as usize..(*end - base_index) as usize]
+                    {
+                        cost += lengths[lit as usize] as u32;
+                    }
+                }
+                Symbol::Backref {
+                    length, dist_sym, ..
+                } => {
+                    let sym = LENGTH_TO_SYMBOL[*length as usize - 3] as usize;
+                    cost += lengths[sym] as u32
+                        + LENGTH_TO_LEN_EXTRA[*length as usize - 3] as u32
+                        + dist_lengths[*dist_sym as usize] as u32
+                        + DIST_SYM_TO_DIST_EXTRA[*dist_sym as usize] as u32;
+                }
+            }
+        }
+
+        if cost > 4 + data.len() as u32 {
+            if eof {
+                writer.write_bits(0b001, 3)?; // final block
+            } else {
+                writer.write_bits(0b000, 3)?; // non-final block
+            }
+
+            let writter_inner = writer.flush()?;
+            writter_inner.write_all(&(data.len() as u16).to_le_bytes())?;
+            writter_inner.write_all(&(!(data.len() as u16)).to_le_bytes())?;
+            writter_inner.write_all(&data)?;
+            return Ok(());
+        }
+    }
+
     if eof {
         writer.write_bits(0b101, 3)?; // final block
     } else {

--- a/src/compress/bitstream.rs
+++ b/src/compress/bitstream.rs
@@ -167,7 +167,7 @@ pub(crate) fn write_block<W: Write>(
             let writter_inner = writer.flush()?;
             writter_inner.write_all(&(data.len() as u16).to_le_bytes())?;
             writter_inner.write_all(&(!(data.len() as u16)).to_le_bytes())?;
-            writter_inner.write_all(&data)?;
+            writter_inner.write_all(data)?;
             return Ok(());
         } else if fixed_cost < dynamic_cost {
             use_fixed_block = true;

--- a/src/compress/bitstream.rs
+++ b/src/compress/bitstream.rs
@@ -8,8 +8,8 @@ use std::{
 use crate::{
     compress::BitWriter,
     tables::{
-        BITMASKS, CLCL_ORDER, DIST_SYM_TO_DIST_BASE, DIST_SYM_TO_DIST_EXTRA, LENGTH_TO_LEN_EXTRA,
-        LENGTH_TO_SYMBOL,
+        BITMASKS, CLCL_ORDER, DIST_SYM_TO_DIST_BASE, DIST_SYM_TO_DIST_EXTRA, FIXED_CODE_LENGTHS,
+        FIXED_DIST_CODES, FIXED_LITLEN_CODES, LENGTH_TO_LEN_EXTRA, LENGTH_TO_SYMBOL,
     },
 };
 
@@ -116,15 +116,19 @@ pub(crate) fn write_block<W: Write>(
         7,
     );
 
-    // If the input is small, then check whether and uncompressed block would be
-    // cheaper.
+    // If the input is small, then check whether an uncompressed block or a
+    // fixed code block would be cheaper.
+    let mut use_fixed_block = false;
     if data.len() < 1024 {
-        let mut cost = 14 + 19 * 3;
+        let stored_cost = (4 + data.len() as u32) * 8;
+        let mut dynamic_cost = 14 + 19 * 3;
+        let mut fixed_cost = 0;
+
         for &length in lengths[..num_litlen_codes]
             .iter()
             .chain(&dist_lengths[..num_dist_codes])
         {
-            cost += code_length_lengths[length as usize] as u32;
+            dynamic_cost += code_length_lengths[length as usize] as u32;
         }
 
         for symbol in symbols {
@@ -132,26 +136,32 @@ pub(crate) fn write_block<W: Write>(
                 Symbol::LiteralRun { start, end } => {
                     for &lit in &data[(*start - base_index) as usize..(*end - base_index) as usize]
                     {
-                        cost += lengths[lit as usize] as u32;
+                        dynamic_cost += lengths[lit as usize] as u32;
+                        fixed_cost += FIXED_CODE_LENGTHS[lit as usize] as u32;
                     }
                 }
                 Symbol::Backref {
                     length, dist_sym, ..
                 } => {
                     let sym = LENGTH_TO_SYMBOL[*length as usize - 3] as usize;
-                    cost += lengths[sym] as u32
-                        + LENGTH_TO_LEN_EXTRA[*length as usize - 3] as u32
-                        + dist_lengths[*dist_sym as usize] as u32
+                    let extra_bits = LENGTH_TO_LEN_EXTRA[*length as usize - 3] as u32
                         + DIST_SYM_TO_DIST_EXTRA[*dist_sym as usize] as u32;
+
+                    dynamic_cost +=
+                        lengths[sym] as u32 + dist_lengths[*dist_sym as usize] as u32 + extra_bits;
+                    fixed_cost += FIXED_CODE_LENGTHS[sym] as u32 + 5 + extra_bits;
                 }
             }
         }
 
-        if cost > 4 + data.len() as u32 {
+        dynamic_cost += lengths[256] as u32;
+        fixed_cost += FIXED_CODE_LENGTHS[256] as u32;
+
+        if stored_cost < dynamic_cost && stored_cost < fixed_cost {
             if eof {
-                writer.write_bits(0b001, 3)?; // final block
+                writer.write_bits(1, 3)?;
             } else {
-                writer.write_bits(0b000, 3)?; // non-final block
+                writer.write_bits(0, 3)?;
             }
 
             let writter_inner = writer.flush()?;
@@ -159,31 +169,46 @@ pub(crate) fn write_block<W: Write>(
             writter_inner.write_all(&(!(data.len() as u16)).to_le_bytes())?;
             writter_inner.write_all(&data)?;
             return Ok(());
+        } else if fixed_cost < dynamic_cost {
+            use_fixed_block = true;
         }
     }
 
-    if eof {
-        writer.write_bits(0b101, 3)?; // final block
+    if use_fixed_block {
+        if eof {
+            writer.write_bits(0b11, 3)?;
+        } else {
+            writer.write_bits(0b10, 3)?;
+        }
+
+        lengths.copy_from_slice(&FIXED_CODE_LENGTHS[..286]);
+        codes.copy_from_slice(&FIXED_LITLEN_CODES);
+        dist_lengths.fill(5);
+        dist_codes.copy_from_slice(&FIXED_DIST_CODES);
     } else {
-        writer.write_bits(0b100, 3)?; // non-final block
-    }
+        if eof {
+            writer.write_bits(0b101, 3)?; // final block
+        } else {
+            writer.write_bits(0b100, 3)?; // non-final block
+        }
 
-    writer.write_bits(num_litlen_codes as u64 - 257, 5)?; // hlit
-    writer.write_bits(num_dist_codes as u64 - 1, 5)?; // hdist
-    writer.write_bits(15, 4)?; // hclen
+        writer.write_bits(num_litlen_codes as u64 - 257, 5)?; // hlit
+        writer.write_bits(num_dist_codes as u64 - 1, 5)?; // hdist
+        writer.write_bits(15, 4)?; // hclen
 
-    for j in 0..19 {
-        writer.write_bits(code_length_lengths[CLCL_ORDER[j]] as u64, 3)?;
-    }
+        for j in 0..19 {
+            writer.write_bits(code_length_lengths[CLCL_ORDER[j]] as u64, 3)?;
+        }
 
-    for &length in lengths[..num_litlen_codes]
-        .iter()
-        .chain(&dist_lengths[..num_dist_codes])
-    {
-        writer.write_bits(
-            code_length_codes[length as usize] as u64,
-            code_length_lengths[length as usize],
-        )?;
+        for &length in lengths[..num_litlen_codes]
+            .iter()
+            .chain(&dist_lengths[..num_dist_codes])
+        {
+            writer.write_bits(
+                code_length_codes[length as usize] as u64,
+                code_length_lengths[length as usize],
+            )?;
+        }
     }
 
     for symbol in symbols {

--- a/src/compress/parse/mod.rs
+++ b/src/compress/parse/mod.rs
@@ -138,7 +138,13 @@ impl<M: MatchFinder> ParserInner<M> {
         // Write the block if we have enough symbols.
         if self.symbols.len() >= 16384 {
             let last_block = flush == Flush::Finish && self.last_match == data.len();
-            bitstream::write_block(writer, data, base_index, &self.symbols, last_block)?;
+            bitstream::write_block(
+                writer,
+                &data[self.last_block_end..self.last_match],
+                base_index + self.last_block_end as u32,
+                &self.symbols,
+                last_block,
+            )?;
             self.symbols.clear();
             self.last_block_end = self.last_match;
         }
@@ -171,7 +177,13 @@ impl<M: MatchFinder> ParserInner<M> {
             assert_eq!(self.ip, data.len());
 
             let last_block = flush == Flush::Finish;
-            bitstream::write_block(writer, data, base_index, &self.symbols, last_block)?;
+            bitstream::write_block(
+                writer,
+                &data[self.last_block_end..self.ip],
+                base_index + self.last_block_end as u32,
+                &self.symbols,
+                last_block,
+            )?;
             self.symbols.clear();
             self.last_block_end = self.ip;
         }

--- a/src/tables.rs
+++ b/src/tables.rs
@@ -201,10 +201,7 @@ pub(crate) const FIXED_DIST_TABLE: [u32; 32] = [
     201427461, 12682757, 5,
 ];
 
-#[cfg(test)]
 pub(crate) const FIXED_CODE_LENGTHS: [u8; 320] = make_fixed_code_lengths();
-
-#[cfg(test)]
 const fn make_fixed_code_lengths() -> [u8; 320] {
     let mut i = 0;
     let mut lengths = [0; 320];
@@ -229,4 +226,40 @@ const fn make_fixed_code_lengths() -> [u8; 320] {
         i += 1;
     }
     lengths
+}
+
+pub(crate) const FIXED_LITLEN_CODES: [u16; 286] = make_fixed_litlen_codes();
+const fn make_fixed_litlen_codes() -> [u16; 286] {
+    let mut codes = [0; 286];
+
+    let mut i = 0;
+    while i <= 143 {
+        codes[i] = (0b00110000 + i as u16).reverse_bits() >> 8;
+        i += 1;
+    }
+    while i <= 255 {
+        codes[i] = (0b110010000 + (i - 144) as u16).reverse_bits() >> 7;
+        i += 1;
+    }
+    while i <= 279 {
+        codes[i] = ((i - 256) as u16).reverse_bits() >> 9;
+        i += 1;
+    }
+    while i <= 285 {
+        codes[i] = (0b11000000 + (i - 280) as u16).reverse_bits() >> 8;
+        i += 1;
+    }
+    codes
+}
+
+pub(crate) const FIXED_DIST_CODES: [u16; 30] = make_fixed_dist_codes();
+const fn make_fixed_dist_codes() -> [u16; 30] {
+    let mut codes = [0; 30];
+
+    let mut i = 0;
+    while i < 30 {
+        codes[i] = (i as u16).reverse_bits() >> 11;
+        i += 1;
+    }
+    codes
 }


### PR DESCRIPTION
This adds logic in the compressor to check any block less than 1KiB to see whether it would be better with a stored block ("type 0") or a fixed code block ("type 1"). The benefit of those other block kinds is that they don't have the fixed overhead of writing a block header like dynamic Huffman code blocks do, but the data ends up less compressed / not compressed at all.