### PR TITLE
Add #[inline] annotations to hot compression functions, improving performance

### DIFF
--- a/src/compress/matchfinder/hybrid.rs
+++ b/src/compress/matchfinder/hybrid.rs
@@ -37,6 +37,9 @@ impl HybridMatchFinder {
         }
     }
 
+    // inlining improves Silesia compression benchmark:
+    // from 23MB/s to 27MB/s at level 6, from 18MB/s to 22MB/s at level 9
+    #[inline]
     fn lookup(
         &mut self,
         data: &[u8],
@@ -140,6 +143,9 @@ impl HybridMatchFinder {
 }
 
 impl MatchFinder for HybridMatchFinder {
+    // inlining improves Silesia compression benchmark:
+    // from 23MB/s to 27MB/s at level 6, from 18MB/s to 22MB/s at level 9
+    #[inline]
     fn get_and_insert(
         &mut self,
         data: &[u8],

--- a/src/compress/matchfinder/hybrid.rs
+++ b/src/compress/matchfinder/hybrid.rs
@@ -37,9 +37,7 @@ impl HybridMatchFinder {
         }
     }
 
-    // inlining improves Silesia compression benchmark:
-    // from 23MB/s to 27MB/s at level 6, from 18MB/s to 22MB/s at level 9
-    #[inline]
+    #[inline] // benchmarks indicated this is beneficial, see #74
     fn lookup(
         &mut self,
         data: &[u8],
@@ -143,9 +141,7 @@ impl HybridMatchFinder {
 }
 
 impl MatchFinder for HybridMatchFinder {
-    // inlining improves Silesia compression benchmark:
-    // from 23MB/s to 27MB/s at level 6, from 18MB/s to 22MB/s at level 9
-    #[inline]
+    #[inline] // benchmarks indicated this is beneficial, see #74
     fn get_and_insert(
         &mut self,
         data: &[u8],


### PR DESCRIPTION
Add `#[inline]` annotations to two hot functions, significantly improving compression performance on [my flate2_bench fork](https://github.com/Shnatsel/flate2_bench/tree/fdeflate) with fdeflate added.